### PR TITLE
Test using `devel` installation (reading requirements from engine master) instead of `user`

### DIFF
--- a/.github/workflows/engine_test.yml
+++ b/.github/workflows/engine_test.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install OQ-Engine
       run: |
         curl -O https://raw.githubusercontent.com/gem/oq-engine/master/install.py
-        python install.py user
+        python install.py devel
     - name: Run tests
       run: |
         source ~/openquake/bin/activate


### PR DESCRIPTION
The devel installation installs engine from master and uses the corresponding requirements.